### PR TITLE
Support device pixel ratio

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -11,12 +11,12 @@
 <h2>Example One</h2>
 
 <dl>
-	<dt>Dataset:</dt>
-	<dd>5, 12, 14, 6, 8, 4, 0, 4, 8, 12, 1, 0, 0, 14, 15</dd>
-	<dt>Canvas Dimensions:</dt>
-	<dd>100 x 15</dd>
-	<dt>Enpoint:</dt>
-	<dd>true</dd>
+  <dt>Dataset:</dt>
+  <dd>5, 12, 14, 6, 8, 4, 0, 4, 8, 12, 1, 0, 0, 14, 15</dd>
+  <dt>Canvas Dimensions:</dt>
+  <dd>100 x 15</dd>
+  <dt>Enpoint:</dt>
+  <dd>true</dd>
 </dl>
 
 <canvas id="example1" width=100 height=15></canvas>
@@ -24,12 +24,12 @@
 <h2>Example Two</h2>
 
 <dl>
-	<dt>Dataset:</dt>
-	<dd>113, 78, 89, 34, 12, 45, 67, 89, 112, 134, 123, 102, 78, 34, 23, 21, 45, 63, 54, 89</dd>
-	<dt>Canvas Dimensions:</dt>
-	<dd>75 x 20</dd>
-	<dt>Enpoint:</dt>
-	<dd>false</dd>
+  <dt>Dataset:</dt>
+  <dd>113, 78, 89, 34, 12, 45, 67, 89, 112, 134, 123, 102, 78, 34, 23, 21, 45, 63, 54, 89</dd>
+  <dt>Canvas Dimensions:</dt>
+  <dd>75 x 20</dd>
+  <dt>Enpoint:</dt>
+  <dd>false</dd>
 </dl>
 
 <canvas id="example2" width=75 height=20></canvas>
@@ -37,12 +37,12 @@
 <h2>Example Three</h2>
 
 <dl>
-	<dt>Dataset:</dt>
-	<dd>1345, 1267, 1178, 891, 1349, 1567, 1891, 1921, 2045, 2102, 2391, 2197, 1899, 1456, 1209, 781, 567, 344</dd>
-	<dt>Canvas Dimensions:</dt>
-	<dd>100 x 15</dd>
-	<dt>Enpoint:</dt>
-	<dd>true</dd>
+  <dt>Dataset:</dt>
+  <dd>1345, 1267, 1178, 891, 1349, 1567, 1891, 1921, 2045, 2102, 2391, 2197, 1899, 1456, 1209, 781, 567, 344</dd>
+  <dt>Canvas Dimensions:</dt>
+  <dd>100 x 15</dd>
+  <dt>Enpoint:</dt>
+  <dd>true</dd>
 </dl>
 
 <canvas id="example3" width=100 height=15></canvas>
@@ -50,12 +50,12 @@
 <h2>Example Four</h2>
 
 <dl>
-	<dt>Dataset:</dt>
-	<dd>9, 37, 23, 28, 44, 26, 43, 43, 24, 33, 17, 18, 35, 31, 30, 49, 32, 25, 48, 37, 45, 20, 23, 34, 37, 26, 34, 38, 37, 34, 23, 26, 34, 37, 18, 39, 33, 28, 27, 24, 22, 35, 24, 38, 50, 45, 41, 18, 34, 19, 9</dd>
-	<dt>Canvas Dimensions:</dt>
-	<dd>100 x 25</dd>
-	<dt>Enpoint:</dt>
-	<dd>true</dd>
+  <dt>Dataset:</dt>
+  <dd>9, 37, 23, 28, 44, 26, 43, 43, 24, 33, 17, 18, 35, 31, 30, 49, 32, 25, 48, 37, 45, 20, 23, 34, 37, 26, 34, 38, 37, 34, 23, 26, 34, 37, 18, 39, 33, 28, 27, 24, 22, 35, 24, 38, 50, 45, 41, 18, 34, 19, 9</dd>
+  <dt>Canvas Dimensions:</dt>
+  <dd>100 x 25</dd>
+  <dt>Enpoint:</dt>
+  <dd>true</dd>
 </dl>
 
 <canvas id="example4" width=100 height=25></canvas>
@@ -63,53 +63,60 @@
 <h2>Example Five</h2>
 
 <dl>
-	<dt>Dataset:</dt>
-	<dd>9, 37, 23, 28, 44, 26, 43, 43, 24, 33, 17, 18, 35, 31, 30, 49, 32, 25, 48, 37, 45, 20, 23, 34, 37, 26, 34, 38, 37, 34, 23, 26, 34, 37, 18, 39, 33, 28, 27, 24, 22, 35, 24, 38, 50, 45, 41, 18, 34, 19, 9</dd>
-	<dt>Canvas Dimensions:</dt>
-	<dd>150 x 25</dd>
-	<dt>Enpoint:</dt>
-	<dd>true</dd>
-	<dt>Color:</dt>
-	<dd>rgba(0,0,255,.5)</dd>
-	<dt>Style:</dt>
-	<dd>bar</dd>
+  <dt>Dataset:</dt>
+  <dd>9, 37, 23, 28, 44, 26, 43, 43, 24, 33, 17, 18, 35, 31, 30, 49, 32, 25, 48, 37, 45, 20, 23, 34, 37, 26, 34, 38, 37, 34, 23, 26, 34, 37, 18, 39, 33, 28, 27, 24, 22, 35, 24, 38, 50, 45, 41, 18, 34, 19, 9</dd>
+  <dt>Canvas Dimensions:</dt>
+  <dd>150 x 25</dd>
+  <dt>Enpoint:</dt>
+  <dd>true</dd>
+  <dt>Color:</dt>
+  <dd>rgba(0,0,255,.5)</dd>
+  <dt>Style:</dt>
+  <dd>bar</dd>
 </dl>
 
 <canvas id="example5" width=150 height=25></canvas>
 
 <script>
 var sparkline = function(canvas_id, data, endpoint, color, style) {
-	if (window.HTMLCanvasElement) {
-		var c = document.getElementById(canvas_id),
-			ctx = c.getContext('2d'),
-			color = (color ? color : 'rgba(0,0,0,.5)'),
-			style = (style == 'bar' ? 'bar' : 'line'),
-			height = c.height - 2,
-			width = c.width,
-			total = data.length,
-			max = Math.max.apply(Math, data),
-			xstep = width/total,
-			ystep = max/height,
-			x = 0,
-			y = height - data[0]/ystep,
-			i;
-		ctx.beginPath();
-		ctx.strokeStyle = color;
-		ctx.moveTo(x, y);
-		for (i = 1; i < total; i = i + 1) {
-			x = x + xstep;
-			y = height - data[i]/ystep + 1;
-			if (style == 'bar') { ctx.moveTo(x,height); }
-			ctx.lineTo(x, y);
-		}
-		ctx.stroke();
-		if (endpoint && style == 'line') {
-			ctx.beginPath();
-			ctx.fillStyle = 'rgba(255,0,0,0.5)';
-			ctx.arc(x, y, 1.5, 0, Math.PI*2);
-			ctx.fill();
-		}
-	}
+  if (window.HTMLCanvasElement) {
+    var c = document.getElementById(canvas_id),
+      ctx = c.getContext('2d'),
+      color = (color ? color : 'rgba(0,0,0,0.5)'),
+      style = (style == 'bar' ? 'bar' : 'line'),
+      height = c.height - 3,
+      width = c.width,
+      total = data.length,
+      max = Math.max.apply(Math, data),
+      xstep = width/total,
+      ystep = max/height,
+      x = 0,
+      y = height - data[0]/ystep,
+      i;
+    c.width = c.width * window.devicePixelRatio;
+    c.height = c.height * window.devicePixelRatio;
+    c.style.width = (c.width / window.devicePixelRatio) + 'px';
+    c.style.height = (c.height / window.devicePixelRatio) + 'px';
+    c.style.display = 'inline-block';
+    ctx.clearRect(0, 0, width, height);
+    ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
+    ctx.beginPath();
+    ctx.strokeStyle = color;
+    ctx.moveTo(x, y);
+    for (i = 1; i < total; i = i + 1) {
+      x = x + xstep;
+      y = height - data[i]/ystep + 2;
+      if (style == 'bar') { ctx.moveTo(x,height); }
+      ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+    if (endpoint && style == 'line') {
+      ctx.beginPath();
+      ctx.fillStyle = 'rgba(255,0,0,0.5)';
+      ctx.arc(x, y, 1.5, 0, Math.PI*2);
+      ctx.fill();
+    }
+  }
 };
 
 

--- a/demo.html
+++ b/demo.html
@@ -11,12 +11,12 @@
 <h2>Example One</h2>
 
 <dl>
-  <dt>Dataset:</dt>
-  <dd>5, 12, 14, 6, 8, 4, 0, 4, 8, 12, 1, 0, 0, 14, 15</dd>
-  <dt>Canvas Dimensions:</dt>
-  <dd>100 x 15</dd>
-  <dt>Enpoint:</dt>
-  <dd>true</dd>
+	<dt>Dataset:</dt>
+	<dd>5, 12, 14, 6, 8, 4, 0, 4, 8, 12, 1, 0, 0, 14, 15</dd>
+	<dt>Canvas Dimensions:</dt>
+	<dd>100 x 15</dd>
+	<dt>Enpoint:</dt>
+	<dd>true</dd>
 </dl>
 
 <canvas id="example1" width=100 height=15></canvas>
@@ -24,12 +24,12 @@
 <h2>Example Two</h2>
 
 <dl>
-  <dt>Dataset:</dt>
-  <dd>113, 78, 89, 34, 12, 45, 67, 89, 112, 134, 123, 102, 78, 34, 23, 21, 45, 63, 54, 89</dd>
-  <dt>Canvas Dimensions:</dt>
-  <dd>75 x 20</dd>
-  <dt>Enpoint:</dt>
-  <dd>false</dd>
+	<dt>Dataset:</dt>
+	<dd>113, 78, 89, 34, 12, 45, 67, 89, 112, 134, 123, 102, 78, 34, 23, 21, 45, 63, 54, 89</dd>
+	<dt>Canvas Dimensions:</dt>
+	<dd>75 x 20</dd>
+	<dt>Enpoint:</dt>
+	<dd>false</dd>
 </dl>
 
 <canvas id="example2" width=75 height=20></canvas>
@@ -37,12 +37,12 @@
 <h2>Example Three</h2>
 
 <dl>
-  <dt>Dataset:</dt>
-  <dd>1345, 1267, 1178, 891, 1349, 1567, 1891, 1921, 2045, 2102, 2391, 2197, 1899, 1456, 1209, 781, 567, 344</dd>
-  <dt>Canvas Dimensions:</dt>
-  <dd>100 x 15</dd>
-  <dt>Enpoint:</dt>
-  <dd>true</dd>
+	<dt>Dataset:</dt>
+	<dd>1345, 1267, 1178, 891, 1349, 1567, 1891, 1921, 2045, 2102, 2391, 2197, 1899, 1456, 1209, 781, 567, 344</dd>
+	<dt>Canvas Dimensions:</dt>
+	<dd>100 x 15</dd>
+	<dt>Enpoint:</dt>
+	<dd>true</dd>
 </dl>
 
 <canvas id="example3" width=100 height=15></canvas>
@@ -50,12 +50,12 @@
 <h2>Example Four</h2>
 
 <dl>
-  <dt>Dataset:</dt>
-  <dd>9, 37, 23, 28, 44, 26, 43, 43, 24, 33, 17, 18, 35, 31, 30, 49, 32, 25, 48, 37, 45, 20, 23, 34, 37, 26, 34, 38, 37, 34, 23, 26, 34, 37, 18, 39, 33, 28, 27, 24, 22, 35, 24, 38, 50, 45, 41, 18, 34, 19, 9</dd>
-  <dt>Canvas Dimensions:</dt>
-  <dd>100 x 25</dd>
-  <dt>Enpoint:</dt>
-  <dd>true</dd>
+	<dt>Dataset:</dt>
+	<dd>9, 37, 23, 28, 44, 26, 43, 43, 24, 33, 17, 18, 35, 31, 30, 49, 32, 25, 48, 37, 45, 20, 23, 34, 37, 26, 34, 38, 37, 34, 23, 26, 34, 37, 18, 39, 33, 28, 27, 24, 22, 35, 24, 38, 50, 45, 41, 18, 34, 19, 9</dd>
+	<dt>Canvas Dimensions:</dt>
+	<dd>100 x 25</dd>
+	<dt>Enpoint:</dt>
+	<dd>true</dd>
 </dl>
 
 <canvas id="example4" width=100 height=25></canvas>
@@ -63,60 +63,60 @@
 <h2>Example Five</h2>
 
 <dl>
-  <dt>Dataset:</dt>
-  <dd>9, 37, 23, 28, 44, 26, 43, 43, 24, 33, 17, 18, 35, 31, 30, 49, 32, 25, 48, 37, 45, 20, 23, 34, 37, 26, 34, 38, 37, 34, 23, 26, 34, 37, 18, 39, 33, 28, 27, 24, 22, 35, 24, 38, 50, 45, 41, 18, 34, 19, 9</dd>
-  <dt>Canvas Dimensions:</dt>
-  <dd>150 x 25</dd>
-  <dt>Enpoint:</dt>
-  <dd>true</dd>
-  <dt>Color:</dt>
-  <dd>rgba(0,0,255,.5)</dd>
-  <dt>Style:</dt>
-  <dd>bar</dd>
+	<dt>Dataset:</dt>
+	<dd>9, 37, 23, 28, 44, 26, 43, 43, 24, 33, 17, 18, 35, 31, 30, 49, 32, 25, 48, 37, 45, 20, 23, 34, 37, 26, 34, 38, 37, 34, 23, 26, 34, 37, 18, 39, 33, 28, 27, 24, 22, 35, 24, 38, 50, 45, 41, 18, 34, 19, 9</dd>
+	<dt>Canvas Dimensions:</dt>
+	<dd>150 x 25</dd>
+	<dt>Enpoint:</dt>
+	<dd>true</dd>
+	<dt>Color:</dt>
+	<dd>rgba(0,0,255,.5)</dd>
+	<dt>Style:</dt>
+	<dd>bar</dd>
 </dl>
 
 <canvas id="example5" width=150 height=25></canvas>
 
 <script>
 var sparkline = function(canvas_id, data, endpoint, color, style) {
-  if (window.HTMLCanvasElement) {
-    var c = document.getElementById(canvas_id),
-      ctx = c.getContext('2d'),
-      color = (color ? color : 'rgba(0,0,0,0.5)'),
-      style = (style == 'bar' ? 'bar' : 'line'),
-      height = c.height - 3,
-      width = c.width,
-      total = data.length,
-      max = Math.max.apply(Math, data),
-      xstep = width/total,
-      ystep = max/height,
-      x = 0,
-      y = height - data[0]/ystep,
-      i;
-    c.width = c.width * window.devicePixelRatio;
-    c.height = c.height * window.devicePixelRatio;
-    c.style.width = (c.width / window.devicePixelRatio) + 'px';
-    c.style.height = (c.height / window.devicePixelRatio) + 'px';
-    c.style.display = 'inline-block';
-    ctx.clearRect(0, 0, width, height);
-    ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
-    ctx.beginPath();
-    ctx.strokeStyle = color;
-    ctx.moveTo(x, y);
-    for (i = 1; i < total; i = i + 1) {
-      x = x + xstep;
-      y = height - data[i]/ystep + 2;
-      if (style == 'bar') { ctx.moveTo(x,height); }
-      ctx.lineTo(x, y);
-    }
-    ctx.stroke();
-    if (endpoint && style == 'line') {
-      ctx.beginPath();
-      ctx.fillStyle = 'rgba(255,0,0,0.5)';
-      ctx.arc(x, y, 1.5, 0, Math.PI*2);
-      ctx.fill();
-    }
-  }
+	if (window.HTMLCanvasElement) {
+		var c = document.getElementById(canvas_id),
+			ctx = c.getContext('2d'),
+			color = (color ? color : 'rgba(0,0,0,0.5)'),
+			style = (style == 'bar' ? 'bar' : 'line'),
+			height = c.height - 3,
+			width = c.width,
+			total = data.length,
+			max = Math.max.apply(Math, data),
+			xstep = width/total,
+			ystep = max/height,
+			x = 0,
+			y = height - data[0]/ystep,
+			i;
+		c.width = c.width * window.devicePixelRatio;
+		c.height = c.height * window.devicePixelRatio;
+		c.style.width = (c.width / window.devicePixelRatio) + 'px';
+		c.style.height = (c.height / window.devicePixelRatio) + 'px';
+		c.style.display = 'inline-block';
+		ctx.clearRect(0, 0, width, height);
+		ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
+		ctx.beginPath();
+		ctx.strokeStyle = color;
+		ctx.moveTo(x, y);
+		for (i = 1; i < total; i = i + 1) {
+			x = x + xstep;
+			y = height - data[i]/ystep + 2;
+			if (style == 'bar') { ctx.moveTo(x,height); }
+			ctx.lineTo(x, y);
+		}
+		ctx.stroke();
+		if (endpoint && style == 'line') {
+			ctx.beginPath();
+			ctx.fillStyle = 'rgba(255,0,0,0.5)';
+			ctx.arc(x, y, 1.5, 0, Math.PI*2);
+			ctx.fill();
+		}
+	}
 };
 
 

--- a/demo.html
+++ b/demo.html
@@ -93,13 +93,15 @@ var sparkline = function(canvas_id, data, endpoint, color, style) {
 			x = 0,
 			y = height - data[0]/ystep,
 			i;
-		c.width = c.width * window.devicePixelRatio;
-		c.height = c.height * window.devicePixelRatio;
-		c.style.width = (c.width / window.devicePixelRatio) + 'px';
-		c.style.height = (c.height / window.devicePixelRatio) + 'px';
-		c.style.display = 'inline-block';
+		if (window.devicePixelRatio) {
+			c.width = c.width * window.devicePixelRatio;
+			c.height = c.height * window.devicePixelRatio;
+			c.style.width = (c.width / window.devicePixelRatio) + 'px';
+			c.style.height = (c.height / window.devicePixelRatio) + 'px';
+			c.style.display = 'inline-block';
+			ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
+		}
 		ctx.clearRect(0, 0, width, height);
-		ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
 		ctx.beginPath();
 		ctx.strokeStyle = color;
 		ctx.moveTo(x, y);

--- a/readme.mdown
+++ b/readme.mdown
@@ -22,23 +22,23 @@ The <code>demo.html</code> shows a few examples. The distribution of the values 
 
 Place your canvas element wherever you want it to appear in your document:
 
-	<canvas id="mycanvas" width="90" height="18"></canvas>
+  <canvas id="mycanvas" width="90" height="18"></canvas>
 
 You can link to the <code>sparkline.js</code> file at the end of your HTML document and then call the function afterwards:
 
 
-	<script src="sparkline.js"></script>
-	<script>
-	sparkline ('mycanvas', [145, 123, 121, 78, 23, 9, 23, 24, 25, 89, 35, 124, 78, 98], true);
-	</script>
+  <script src="sparkline.js"></script>
+  <script>
+  sparkline ('mycanvas', [145, 123, 121, 78, 23, 9, 23, 24, 25, 89, 35, 124, 78, 98], true);
+  </script>
 
 Or you can inline the <code>sparkline</code> function at the bottom of your document (to avoid the extra HTTP request):
 
-	<script>
-	var sparkline = function(canvas_id, data, endpoint, color, style) {
-	...
-	};
-	sparkline('mycanvas', [145, 123, 121, 78, 23, 9, 23, 24, 25, 89, 35, 124, 78, 98], true, 'rgba(0,0,255,.5)','line');
-	</script>
+  <script>
+  var sparkline = function(canvas_id, data, endpoint, color, style) {
+  ...
+  };
+  sparkline('mycanvas', [145, 123, 121, 78, 23, 9, 23, 24, 25, 89, 35, 124, 78, 98], true, 'rgba(0,0,255,.5)','line');
+  </script>
 
 You can see the script in action on member profiles on the website The Session e.g. <http://thesession.org/members/1>

--- a/readme.mdown
+++ b/readme.mdown
@@ -22,23 +22,23 @@ The <code>demo.html</code> shows a few examples. The distribution of the values 
 
 Place your canvas element wherever you want it to appear in your document:
 
-  <canvas id="mycanvas" width="90" height="18"></canvas>
+	<canvas id="mycanvas" width="90" height="18"></canvas>
 
 You can link to the <code>sparkline.js</code> file at the end of your HTML document and then call the function afterwards:
 
 
-  <script src="sparkline.js"></script>
-  <script>
-  sparkline ('mycanvas', [145, 123, 121, 78, 23, 9, 23, 24, 25, 89, 35, 124, 78, 98], true);
-  </script>
+	<script src="sparkline.js"></script>
+	<script>
+	sparkline ('mycanvas', [145, 123, 121, 78, 23, 9, 23, 24, 25, 89, 35, 124, 78, 98], true);
+	</script>
 
 Or you can inline the <code>sparkline</code> function at the bottom of your document (to avoid the extra HTTP request):
 
-  <script>
-  var sparkline = function(canvas_id, data, endpoint, color, style) {
-  ...
-  };
-  sparkline('mycanvas', [145, 123, 121, 78, 23, 9, 23, 24, 25, 89, 35, 124, 78, 98], true, 'rgba(0,0,255,.5)','line');
-  </script>
+	<script>
+	var sparkline = function(canvas_id, data, endpoint, color, style) {
+	...
+	};
+	sparkline('mycanvas', [145, 123, 121, 78, 23, 9, 23, 24, 25, 89, 35, 124, 78, 98], true, 'rgba(0,0,255,.5)','line');
+	</script>
 
 You can see the script in action on member profiles on the website The Session e.g. <http://thesession.org/members/1>

--- a/sparkline.js
+++ b/sparkline.js
@@ -1,34 +1,40 @@
 var sparkline = function(canvas_id, data, endpoint, color, style) {
-	if (window.HTMLCanvasElement) {
-		var c = document.getElementById(canvas_id),
-			ctx = c.getContext('2d'),
-			color = (color ? color : 'rgba(0,0,0,0.5)'),
-			style = (style == 'bar' ? 'bar' : 'line'),
-			height = c.height - 2,
-			width = c.width,
-			total = data.length,
-			max = Math.max.apply(Math, data),
-			xstep = width/total,
-			ystep = max/height,
-			x = 0,
-			y = height - data[0]/ystep,
-			i;
-		ctx.clearRect(0, 0, width, height);
-		ctx.beginPath();
-		ctx.strokeStyle = color;
-		ctx.moveTo(x, y);
-		for (i = 1; i < total; i = i + 1) {
-			x = x + xstep;
-			y = height - data[i]/ystep + 1;
-			if (style == 'bar') { ctx.moveTo(x,height); }
-			ctx.lineTo(x, y);
-		}
-		ctx.stroke();
-		if (endpoint && style == 'line') {
-			ctx.beginPath();
-			ctx.fillStyle = 'rgba(255,0,0,0.5)';
-			ctx.arc(x, y, 1.5, 0, Math.PI*2);
-			ctx.fill();
-		}
-	}
+  if (window.HTMLCanvasElement) {
+    var c = document.getElementById(canvas_id),
+      ctx = c.getContext('2d'),
+      color = (color ? color : 'rgba(0,0,0,0.5)'),
+      style = (style == 'bar' ? 'bar' : 'line'),
+      height = c.height - 3,
+      width = c.width,
+      total = data.length,
+      max = Math.max.apply(Math, data),
+      xstep = width/total,
+      ystep = max/height,
+      x = 0,
+      y = height - data[0]/ystep,
+      i;
+    c.width = c.width * window.devicePixelRatio;
+    c.height = c.height * window.devicePixelRatio;
+    c.style.width = (c.width / window.devicePixelRatio) + 'px';
+    c.style.height = (c.height / window.devicePixelRatio) + 'px';
+    c.style.display = 'inline-block';
+    ctx.clearRect(0, 0, width, height);
+    ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
+    ctx.beginPath();
+    ctx.strokeStyle = color;
+    ctx.moveTo(x, y);
+    for (i = 1; i < total; i = i + 1) {
+      x = x + xstep;
+      y = height - data[i]/ystep + 2;
+      if (style == 'bar') { ctx.moveTo(x,height); }
+      ctx.lineTo(x, y);
+    }
+    ctx.stroke();
+    if (endpoint && style == 'line') {
+      ctx.beginPath();
+      ctx.fillStyle = 'rgba(255,0,0,0.5)';
+      ctx.arc(x, y, 1.5, 0, Math.PI*2);
+      ctx.fill();
+    }
+  }
 };

--- a/sparkline.js
+++ b/sparkline.js
@@ -1,40 +1,40 @@
 var sparkline = function(canvas_id, data, endpoint, color, style) {
-  if (window.HTMLCanvasElement) {
-    var c = document.getElementById(canvas_id),
-      ctx = c.getContext('2d'),
-      color = (color ? color : 'rgba(0,0,0,0.5)'),
-      style = (style == 'bar' ? 'bar' : 'line'),
-      height = c.height - 3,
-      width = c.width,
-      total = data.length,
-      max = Math.max.apply(Math, data),
-      xstep = width/total,
-      ystep = max/height,
-      x = 0,
-      y = height - data[0]/ystep,
-      i;
-    c.width = c.width * window.devicePixelRatio;
-    c.height = c.height * window.devicePixelRatio;
-    c.style.width = (c.width / window.devicePixelRatio) + 'px';
-    c.style.height = (c.height / window.devicePixelRatio) + 'px';
-    c.style.display = 'inline-block';
-    ctx.clearRect(0, 0, width, height);
-    ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
-    ctx.beginPath();
-    ctx.strokeStyle = color;
-    ctx.moveTo(x, y);
-    for (i = 1; i < total; i = i + 1) {
-      x = x + xstep;
-      y = height - data[i]/ystep + 2;
-      if (style == 'bar') { ctx.moveTo(x,height); }
-      ctx.lineTo(x, y);
-    }
-    ctx.stroke();
-    if (endpoint && style == 'line') {
-      ctx.beginPath();
-      ctx.fillStyle = 'rgba(255,0,0,0.5)';
-      ctx.arc(x, y, 1.5, 0, Math.PI*2);
-      ctx.fill();
-    }
-  }
+	if (window.HTMLCanvasElement) {
+		var c = document.getElementById(canvas_id),
+			ctx = c.getContext('2d'),
+			color = (color ? color : 'rgba(0,0,0,0.5)'),
+			style = (style == 'bar' ? 'bar' : 'line'),
+			height = c.height - 3,
+			width = c.width,
+			total = data.length,
+			max = Math.max.apply(Math, data),
+			xstep = width/total,
+			ystep = max/height,
+			x = 0,
+			y = height - data[0]/ystep,
+			i;
+		c.width = c.width * window.devicePixelRatio;
+		c.height = c.height * window.devicePixelRatio;
+		c.style.width = (c.width / window.devicePixelRatio) + 'px';
+		c.style.height = (c.height / window.devicePixelRatio) + 'px';
+		c.style.display = 'inline-block';
+		ctx.clearRect(0, 0, width, height);
+		ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
+		ctx.beginPath();
+		ctx.strokeStyle = color;
+		ctx.moveTo(x, y);
+		for (i = 1; i < total; i = i + 1) {
+			x = x + xstep;
+			y = height - data[i]/ystep + 2;
+			if (style == 'bar') { ctx.moveTo(x,height); }
+			ctx.lineTo(x, y);
+		}
+		ctx.stroke();
+		if (endpoint && style == 'line') {
+			ctx.beginPath();
+			ctx.fillStyle = 'rgba(255,0,0,0.5)';
+			ctx.arc(x, y, 1.5, 0, Math.PI*2);
+			ctx.fill();
+		}
+	}
 };

--- a/sparkline.js
+++ b/sparkline.js
@@ -13,13 +13,15 @@ var sparkline = function(canvas_id, data, endpoint, color, style) {
 			x = 0,
 			y = height - data[0]/ystep,
 			i;
-		c.width = c.width * window.devicePixelRatio;
-		c.height = c.height * window.devicePixelRatio;
-		c.style.width = (c.width / window.devicePixelRatio) + 'px';
-		c.style.height = (c.height / window.devicePixelRatio) + 'px';
-		c.style.display = 'inline-block';
+		if (window.devicePixelRatio) {
+			c.width = c.width * window.devicePixelRatio;
+			c.height = c.height * window.devicePixelRatio;
+			c.style.width = (c.width / window.devicePixelRatio) + 'px';
+			c.style.height = (c.height / window.devicePixelRatio) + 'px';
+			c.style.display = 'inline-block';
+			ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
+		}
 		ctx.clearRect(0, 0, width, height);
-		ctx.scale(window.devicePixelRatio, window.devicePixelRatio);
 		ctx.beginPath();
 		ctx.strokeStyle = color;
 		ctx.moveTo(x, y);


### PR DESCRIPTION
Adds support for device pixel ratios greater than 1 and fixes endpoint clipping when the last data point is the highest value.

**Before**
<img width="110" alt="screen shot 2016-06-08 at 3 16 48 pm" src="https://cloud.githubusercontent.com/assets/114522/15907805/a78e715c-2d8c-11e6-9e08-7e6bca5848e5.png"> <img width="40" alt="screen shot 2016-06-08 at 3 17 12 pm" src="https://cloud.githubusercontent.com/assets/114522/15907821/b65789c6-2d8c-11e6-82db-646a3a267a27.png">

**After**
<img width="110" alt="screen shot 2016-06-08 at 3 16 15 pm" src="https://cloud.githubusercontent.com/assets/114522/15907812/acf93ee2-2d8c-11e6-9fb1-1763cfc53d99.png"> <img width="30" alt="screen shot 2016-06-08 at 3 24 20 pm" src="https://cloud.githubusercontent.com/assets/114522/15907911/1b6473d8-2d8d-11e6-8d92-c60256c6f7eb.png">
